### PR TITLE
Add tests for the `Request` object.

### DIFF
--- a/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestAddValueTests.swift
+++ b/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestAddValueTests.swift
@@ -45,6 +45,18 @@ final class HTTPRequestAddValueTests: XCTestCase {
         // Then
         XCTAssertEqual(request.allHTTPHeaders, [headerName: headerValue])
     }
+    
+    func testAddsNewHeaderValueWhenTheHeaderNameIsEmptyString() {
+        // Given
+        let headerName = ""
+        let headerValue = "A"
+
+        // When
+        request.addValue(headerValue, for: headerName)
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaders, [headerName: headerValue])
+    }
 
     func testAddsNewHeaderValueWhenAllHeadersContainSuchHeader() {
         // Given
@@ -61,7 +73,7 @@ final class HTTPRequestAddValueTests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaders, [headerName: expectedHeaderValue])
     }
 
-    func testAddsEmptyStringAndSpaceToExistingHeader() {
+    func testAddsEmptyStringAndSpaceToHeaderValue() {
         // Given
         let headerName = "A"
         let headerValueOne = " "

--- a/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestAddValueTests.swift
+++ b/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestAddValueTests.swift
@@ -1,0 +1,82 @@
+import NetworkService
+import XCTest
+
+final class HTTPRequestAddValueTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        request = HTTPRequest(
+            URI: URL(string: "https://www.example.com")!,
+            requestMethod: .post
+        )
+    }
+
+    func testCreatesNewHeaderWhenAllHeadersIsEmpty() {
+        // Given
+        let headerName = "A"
+        let headerValue = "B"
+
+        // When
+        request.addValue(headerValue, for: headerName)
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaders, [headerName: headerValue])
+    }
+
+    func testAddsNewHeaderValueWhenTheHeaderValueIsEmptyString() {
+        // Given
+        let headerName = "A"
+        let headerValue = ""
+
+        // When
+        request.addValue(headerValue, for: headerName)
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaders, [headerName: headerValue])
+    }
+
+    func testAddsNewHeaderValueWhenTheHeaderValueIsSpace() {
+        // Given
+        let headerName = "A"
+        let headerValue = " "
+
+        // When
+        request.addValue(headerValue, for: headerName)
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaders, [headerName: headerValue])
+    }
+
+    func testAddsNewHeaderValueWhenAllHeadersContainSuchHeader() {
+        // Given
+        let headerName = "A"
+        let headerValueOne = "B"
+        let headerValueTwo = "C"
+        let expectedHeaderValue = "B,C"
+        request.addValue(headerValueOne, for: headerName)
+
+        // When
+        request.addValue(headerValueTwo, for: headerName)
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaders, [headerName: expectedHeaderValue])
+    }
+
+    func testAddsEmptyStringAndSpaceToExistingHeader() {
+        // Given
+        let headerName = "A"
+        let headerValueOne = " "
+        let headerValueTwo = ""
+        let expectedHeaderValue = " ,"
+
+        // When
+        request.addValue(headerValueOne, for: headerName)
+        request.addValue(headerValueTwo, for: headerName)
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaders, [headerName: expectedHeaderValue])
+    }
+
+    // MARK: - Private interface
+
+    private var request: HTTPRequest!
+}

--- a/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestAllHTTPHeadersTests.swift
+++ b/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestAllHTTPHeadersTests.swift
@@ -1,0 +1,39 @@
+import NetworkService
+import XCTest
+
+final class HTTPRequestAllHTTPHeadersTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        request = HTTPRequest(
+            URI: URL(string: "https://www.example.com")!,
+            requestMethod: .get
+        )
+    }
+
+    func testReturnsAddedHeaders() {
+        // Given
+        let headerNameOne = "A"
+        let headerNameTwo = "B"
+        let headerValueOne = "a"
+        let headerValueTwo = "b"
+        let expectedHeaders = [
+            headerNameOne.lowercased(): headerValueOne,
+            headerNameTwo.lowercased(): headerValueTwo,
+        ]
+
+        // When
+        request.addValue(headerValueOne, for: headerNameOne)
+        request.addValue(headerValueTwo, for: headerNameTwo)
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaders, expectedHeaders)
+    }
+
+    func testReturnsEmptyDictionaryIfNoOneHeaderIsAdded() {
+        XCTAssertEqual(request.allHTTPHeaders, [:])
+    }
+
+    // MARK: - Private interface
+
+    private var request: HTTPRequest!
+}

--- a/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestInitTests.swift
+++ b/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestInitTests.swift
@@ -1,0 +1,50 @@
+import NetworkService
+import XCTest
+
+final class HTTPRequestInitTests: XCTestCase {
+    func testCreateNewInstanceWithExpectedPropertyValues() {
+        // Given
+        let url = URL(string: "https://www.example.com")!
+        let httpMethod = HTTPMethod.post
+        let body = ""
+
+        // When
+        let requestWithoutBody = HTTPRequest(
+            URI: url,
+            requestMethod: httpMethod
+        )
+        let requestWithBody = HTTPRequest(
+            URI: url,
+            requestMethod: httpMethod,
+            body: body
+        )
+
+        // Then
+        XCTAssertEqual(requestWithoutBody.URI, url)
+        XCTAssertEqual(requestWithoutBody.requestMethod, httpMethod)
+        XCTAssertEqual(requestWithoutBody.allHTTPHeaders, [:])
+        XCTAssertNil(requestWithoutBody.body)
+
+        XCTAssertEqual(requestWithBody.URI, url)
+        XCTAssertEqual(requestWithBody.requestMethod, httpMethod)
+        XCTAssertEqual(requestWithBody.allHTTPHeaders, [:])
+        XCTAssertEqual(requestWithBody.body, body)
+    }
+
+    func testNewInstanceHasNilBodyIfHTTPMethodIsGetAndBodyIsPassed() {
+        // Given
+        let url = URL(string: "https://www.example.com")!
+        let httpMethod = HTTPMethod.get
+        let body = ""
+
+        // When
+        let requestWithBody = HTTPRequest(
+            URI: url,
+            requestMethod: httpMethod,
+            body: body
+        )
+
+        // Then
+        XCTAssertNil(requestWithBody.body)
+    }
+}

--- a/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestInitTests.swift
+++ b/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestInitTests.swift
@@ -2,7 +2,7 @@ import NetworkService
 import XCTest
 
 final class HTTPRequestInitTests: XCTestCase {
-    func testCreateNewInstanceWithExpectedPropertyValues() {
+    func testCreatesNewInstanceWithExpectedPropertyValues() {
         // Given
         let url = URL(string: "https://www.example.com")!
         let httpMethod = HTTPMethod.post

--- a/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestInitTests.swift
+++ b/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestInitTests.swift
@@ -4,7 +4,6 @@ import XCTest
 final class HTTPRequestInitTests: XCTestCase {
     func testCreatesNewInstanceWithExpectedPropertyValues() {
         // Given
-        let url = URL(string: "https://www.example.com")!
         let httpMethod = HTTPMethod.post
         let body = ""
 
@@ -33,18 +32,20 @@ final class HTTPRequestInitTests: XCTestCase {
 
     func testNewInstanceHasNilBodyIfHTTPMethodIsGetAndBodyIsPassed() {
         // Given
-        let url = URL(string: "https://www.example.com")!
-        let httpMethod = HTTPMethod.get
         let body = ""
 
         // When
         let requestWithBody = HTTPRequest(
             URI: url,
-            requestMethod: httpMethod,
+            requestMethod: .get,
             body: body
         )
 
         // Then
         XCTAssertNil(requestWithBody.body)
     }
+
+    // MARK: - Private interface
+
+    private let url = URL(string: "https://www.example.com")!
 }

--- a/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestSetValueTests.swift
+++ b/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestSetValueTests.swift
@@ -1,0 +1,79 @@
+import NetworkService
+import XCTest
+
+final class HTTPRequestSetValueTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        request = HTTPRequest(
+            URI: URL(string: "https://www.example.com")!,
+            requestMethod: .post
+        )
+    }
+
+    func testCreatesNewHeaderWhenAllHeadersIsEmpty() {
+        // Given
+        let headerName = "A"
+        let headerValue = "B"
+
+        // When
+        request.setValue(headerValue, for: headerName)
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaders, [headerName: headerValue])
+    }
+
+    func testCreatesNewHeaderWhenTheHeaderValueIsEmptyString() {
+        // Given
+        let headerName = "A"
+        let headerValue = ""
+
+        // When
+        request.setValue(headerValue, for: headerName)
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaders, [headerName: headerValue])
+    }
+
+    func testCreatesNewHeaderWhenTheHeaderValueIsSpace() {
+        // Given
+        let headerName = "A"
+        let headerValue = " "
+
+        // When
+        request.setValue(headerValue, for: headerName)
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaders, [headerName: headerValue])
+    }
+
+    func testOverridesThePreviousHeaderValue() {
+        // Given
+        let headerName = "A"
+        let initialHeaderValue = "B"
+        let overridingHeaderValue = "C"
+        request.addValue(initialHeaderValue, for: headerName)
+
+        // When
+        request.setValue(overridingHeaderValue, for: headerName)
+
+        // Then
+        XCTAssertEqual(request.allHTTPHeaders, [headerName: overridingHeaderValue])
+    }
+
+    func testDeletesHeaderIfTheSetHeaderValueIsNil() {
+        // Given
+        let headerName = "A"
+        let initialHeaderValue = "B"
+        request.addValue(initialHeaderValue, for: headerName)
+
+        // When
+        request.setValue(nil, for: headerName)
+
+        // Then
+        XCTAssertNil(request.value(for: headerName))
+    }
+
+    // MARK: - Private interface
+
+    private var request: HTTPRequest!
+}

--- a/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestSetValueTests.swift
+++ b/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestSetValueTests.swift
@@ -19,7 +19,7 @@ final class HTTPRequestSetValueTests: XCTestCase {
         request.setValue(headerValue, for: headerName)
 
         // Then
-        XCTAssertEqual(request.allHTTPHeaders, [headerName: headerValue])
+        XCTAssertEqual(request.value(for: headerName), headerValue)
     }
 
     func testCreatesNewHeaderWhenTheHeaderValueIsEmptyString() {
@@ -31,7 +31,7 @@ final class HTTPRequestSetValueTests: XCTestCase {
         request.setValue(headerValue, for: headerName)
 
         // Then
-        XCTAssertEqual(request.allHTTPHeaders, [headerName: headerValue])
+        XCTAssertEqual(request.value(for: headerName), headerValue)
     }
 
     func testCreatesNewHeaderWhenTheHeaderValueIsSpace() {
@@ -43,7 +43,7 @@ final class HTTPRequestSetValueTests: XCTestCase {
         request.setValue(headerValue, for: headerName)
 
         // Then
-        XCTAssertEqual(request.allHTTPHeaders, [headerName: headerValue])
+        XCTAssertEqual(request.value(for: headerName), headerValue)
     }
 
     func testOverridesThePreviousHeaderValue() {
@@ -57,7 +57,7 @@ final class HTTPRequestSetValueTests: XCTestCase {
         request.setValue(overridingHeaderValue, for: headerName)
 
         // Then
-        XCTAssertEqual(request.allHTTPHeaders, [headerName: overridingHeaderValue])
+        XCTAssertEqual(request.value(for: headerName), overridingHeaderValue)
     }
 
     func testDeletesHeaderIfTheSetHeaderValueIsNil() {

--- a/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestValueForHeaderNameTests.swift
+++ b/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestValueForHeaderNameTests.swift
@@ -1,0 +1,45 @@
+import NetworkService
+import XCTest
+
+final class HTTPRequestValueForHeaderNameTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        request = HTTPRequest(
+            URI: URL(string: "https://www.example.com")!,
+            requestMethod: .post
+        )
+    }
+
+    func testReturnsNilIfNoCorrespondingHeaderField() {
+        // Given
+        let headerName = "a"
+
+        // When
+        let headerValue = request.value(for: headerName)
+
+        // Then
+        XCTAssertNil(headerValue)
+    }
+
+    func testReturnsCorrespondingHeaderValue() {
+        // Given
+        let headerNameOne = "a"
+        let headerNameTwo = "b"
+        let headerValueOne = "A"
+        let headerValueTwo = "B"
+        request.setValue(headerValueOne, for: headerNameOne)
+        request.setValue(headerValueTwo, for: headerNameTwo)
+
+        // When
+        let expectedHeaderValueOne = request.value(for: headerNameOne)
+        let expectedHeaderValueTwo = request.value(for: headerNameTwo)
+
+        // Then
+        XCTAssertEqual(expectedHeaderValueOne, headerValueOne)
+        XCTAssertEqual(expectedHeaderValueTwo, headerValueTwo)
+    }
+
+    // MARK: - Private interface
+
+    private var request: HTTPRequest!
+}

--- a/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestValueForHeaderNameTests.swift
+++ b/Tests/NetworkServiceTests/HTTPRequestTests/HTTPRequestValueForHeaderNameTests.swift
@@ -39,6 +39,20 @@ final class HTTPRequestValueForHeaderNameTests: XCTestCase {
         XCTAssertEqual(expectedHeaderValueTwo, headerValueTwo)
     }
 
+    func testHeaderStaysNotModifiedAmongHeadersAfterAccessing() {
+        // Given
+        let headerName = "a"
+        let headerValue = "A"
+        request.setValue(headerValue, for: headerName)
+
+        // When
+        let firstAccessToHeaderValue = request.value(for: headerName)
+        let secondAccessToHeaderValue = request.value(for: headerName)
+
+        // Then
+        XCTAssertEqual(firstAccessToHeaderValue, secondAccessToHeaderValue)
+    }
+
     // MARK: - Private interface
 
     private var request: HTTPRequest!


### PR DESCRIPTION
## Summary
This PR is a part of the work to resolve #3 and it's related with PR [#2](https://github.com/ios-course/simple-network-service/pull/2).

## Changes

- Added to `NetworkServiceTests` target files with `HTTPRequest` tests.

## Checks to complete
- [x] I've built and run my changes, and no warnings or errors occurred.
- [x] All existing tests passed with my changes.
- [x] My code follows our style guide.
- [x] I've performed a self-review of my code.
- [x] PR's title has a conventional commit style (short and descriptive).
- [x] Every non-private interface is documented properly.
- [x] I've added tests for my code (if it makes sense).
- [x] PR has assignee, reviewers, milestone, it is properly linked to the project and to the issue.